### PR TITLE
Support specialization per Operation type

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,15 +53,15 @@ The user has access to a list of all properties associated with a type `T` throu
 Once a list of properties for a type `T` is available it can be used to invoke operations. For each `Property` in the list a corresponding _handler_ function can be associated with it. Handlers are implemented by specializing `PropertyHandler` for wanted combinations of T/Property/Config. `Config` is added as an extra specialization type to serve as a mechanism for passing arguments to handlers.
 
 ```C++
-    template<typename T, typename Property, typename Config = NoConfig>
+    template<typename T, typename Property, typename Config = NoConfig, typename Op = DefaultOp>
     struct PropertyHandler {
         static void handle(Config & /*command*/) = delete;
     };
 ```
-For example, a simplistic handler for T(satisfying HasSomeProperty)/SomeProperty/NoConfig is implemated as:
+For example, a simplistic handler for T(satisfying HasSomeProperty)/SomeProperty/NoConfig/DefaultOp is implemented as:
 ```C++
   // User code
-  // Specialization for T/SomeProperty/NoConfig
+  // Specialization for T/SomeProperty/NoConfig/DefaultOp
   template <HasSomeProperty T>
   struct PropCP::PropertyHandler<T, SomeProperty> {
       static void handle(PropCP::NoConfig& config) {
@@ -70,7 +70,7 @@ For example, a simplistic handler for T(satisfying HasSomeProperty)/SomeProperty
       }
   };
 ```
-The Config type is not written out explicitly as the default is `NoConfig`. Another example with but with a custom 
+The Config type and Op type is not written out explicitly as the default is `NoConfig` and `DefaultOp` respectively. Another example with but with a custom 
 non-default Config type:
 ```C++
 template <typename  T>

--- a/examples/ExampleCmds/include/FooPropertyHandler.h
+++ b/examples/ExampleCmds/include/FooPropertyHandler.h
@@ -18,7 +18,7 @@ struct PropCP::PropertyHandler<T, FooProp> {
 
 // Specialization for T/FooProp/MyConfig
 template <HasFoo T>
-struct PropCP::PropertyHandler<T, FooProp, MyConfig> {
+struct PropCP::PropertyHandler<T, FooProp,  MyConfig, PropCP::DefaultOp> {
     static void handle(const MyConfig & config) {
         std::cout << "Handling FooProp for type: " << typeid(T).name() << " with MyConfig." << std::endl;
         std::cout << "parameter_1 is: " << config.parameter_1 << std::endl;

--- a/examples/ExampleCmds/include/SomeOtherPropertyHandler.h
+++ b/examples/ExampleCmds/include/SomeOtherPropertyHandler.h
@@ -17,7 +17,7 @@ struct PropCP::PropertyHandler<T, SomeOtherProp> {
 };
 
 template <typename  T>
-struct PropCP::PropertyHandler<T, SomeOtherProp, MyConfig> {
+struct PropCP::PropertyHandler<T, SomeOtherProp, MyConfig, PropCP::DefaultOp> {
     static void handle(const MyConfig & config) {
         std::cout << "Handling SomeOtherProp for type: " << typeid(T).name() << " with MyConfig." << std::endl;
         // Example logic

--- a/include/PropCP/dispatch.h
+++ b/include/PropCP/dispatch.h
@@ -6,30 +6,30 @@
 
 namespace PropCP {
 
-    template<typename T, typename PropertyList, typename Config = NoConfig>
+    template<typename T, typename PropertyList, typename Config = NoConfig, typename Op = DefaultOp>
     struct DispatchProperties;
 
     // Base case: Empty property list
-    template<typename T, typename Config>
-    struct DispatchProperties<T, TypeList<>, Config> {
+    template<typename T, typename Config, typename Op>
+    struct DispatchProperties<T, TypeList<>, Config, Op> {
         static void dispatch(const Config &) {
         // Do nothing
         }
     };
 
     // Specialization for a Non-Empty TypeList: Recursive Case
-    template<typename T, typename FirstProperty, typename... RestProperties, typename Config>
-    struct DispatchProperties<T, TypeList<FirstProperty, RestProperties...>, Config> {
+    template<typename T, typename FirstProperty, typename... RestProperties, typename Config, typename Op>
+    struct DispatchProperties<T, TypeList<FirstProperty, RestProperties...>, Config, Op> {
         static void dispatch(Config &config) {
-            static_assert(HasPropertyHandler<T, FirstProperty, Config>,
-                          "Missing PropertyHandler specialization for this T/Property/Config");
+            static_assert(HasPropertyHandler<T, FirstProperty, Config, Op>,
+                          "Missing PropertyHandler specialization for this T/Property/Config/Op");
 
 
             // Handle the first property
-            PropertyHandler<T, FirstProperty, Config>::handle(config);
+            PropertyHandler<T, FirstProperty, Config, Op>::handle(config);
 
             // Recursively handle the rest
-            DispatchProperties<T, TypeList<RestProperties...>, Config>::dispatch(config);
+            DispatchProperties<T, TypeList<RestProperties...>, Config, Op>::dispatch(config);
         }
     };
 

--- a/include/PropCP/handler.h
+++ b/include/PropCP/handler.h
@@ -4,15 +4,17 @@
 namespace PropCP {
     struct NoConfig {};
 
-    template<typename T, typename Property, typename Config = NoConfig>
+    struct DefaultOp {};
+
+    template<typename T, typename Property, typename Config = NoConfig, typename Op = DefaultOp>
     struct PropertyHandler {
         static void handle(Config & /*command*/) = delete;
     };
 
     // Helper concept to check if a handler is callable for given T/Property/Config
-    template<typename T, typename Property, typename Config>
+    template<typename T, typename Property, typename Config, typename Op>
     concept HasPropertyHandler = requires(Config &c) {
-        { PropertyHandler<T, Property, Config>::handle(c) };
+        { PropertyHandler<T, Property, Config, Op>::handle(c) };
     };
 }
 


### PR DESCRIPTION

- Updated `PropertyHandler`, `DispatchProperties`, and associated concepts to include `Op` as a new template parameter.
- Op tags can be used to dispatch on the per-operation basis. default value is DefaultOp. 
- Updated README code examples and explanations to reflect the changes.